### PR TITLE
fix(auth): handle expired/invalid AT Protocol tokens

### DIFF
--- a/src/lib/auth/atproto.ts
+++ b/src/lib/auth/atproto.ts
@@ -1,5 +1,5 @@
 import { AtpAgent } from '@atproto/api';
-import { getSession } from './session';
+import { getSession, deleteSession } from './session';
 
 export async function getAgent(): Promise<AtpAgent | null> {
   const session = await getSession();
@@ -12,16 +12,25 @@ export async function getAgent(): Promise<AtpAgent | null> {
     service: 'https://bsky.social',
   });
 
-  // Resume session
-  await agent.resumeSession({
-    did: session.did,
-    handle: session.handle,
-    accessJwt: session.accessToken,
-    refreshJwt: session.refreshToken,
-    active: true,
-  });
+  try {
+    // Resume session
+    await agent.resumeSession({
+      did: session.did,
+      handle: session.handle,
+      accessJwt: session.accessToken,
+      refreshJwt: session.refreshToken,
+      active: true,
+    });
 
-  return agent;
+    return agent;
+  } catch (error: unknown) {
+    // If token is expired or invalid, clear the session
+    const err = error as { error?: string };
+    if (err.error === 'ExpiredToken' || err.error === 'InvalidToken') {
+      await deleteSession();
+    }
+    return null;
+  }
 }
 
 export async function getProfile(did: string) {


### PR DESCRIPTION
Wrap agent.resumeSession in a try/catch and return null on session
resume failure. If the error indicates an ExpiredToken or InvalidToken,
delete the stored session to avoid repeatedly attempting with a bad
token. Also import deleteSession from session.ts.

This prevents using stale credentials and ensures the app clears
invalid sessions so users can re-authenticate cleanly.