### PR TITLE
fix: pluralize "Lanyard" to "Lards" and tidy JSX formatting

### DIFF
--- a/.docs/brief.md
+++ b/.docs/brief.md
@@ -1,5 +1,5 @@
 # Overview
-'Lanyard' is a dedicated profile for researchers, built on the AT profile.
+'Lanyards' is a dedicated profile for researchers, built on the AT profile.
 
 Researchers will use this as an alternative to the ORCID id.
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <main className="flex min-h-screen flex-col items-center justify-center p-6 bg-gradient-to-b from-white to-gray-50">
       <div className="max-w-2xl w-full text-center">
         <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-transparent">
-          Lanyard
+          Lanyards
         </h1>
         <p className="text-xl text-gray-700 mb-2">
           Your Researcher Profile on the AT Protocol
@@ -45,7 +45,9 @@ export default function Home() {
             </p>
           </div>
           <div className="bg-white p-6 rounded-lg shadow-sm">
-            <h3 className="font-semibold text-lg mb-2">Comprehensive Profile</h3>
+            <h3 className="font-semibold text-lg mb-2">
+              Comprehensive Profile
+            </h3>
             <p className="text-gray-600 text-sm">
               Manage affiliations, publications, events, and social networks all
               in one place.


### PR DESCRIPTION
Update UI text and markup to use the plural "Lanyards" instead
of "Lanyard" across the app and documentation. Also adjust JSX
whitespace for a heading to improve readability and adhere to the
project's JSX formatting style.

- Change main title in page.tsx from "Lanyard" to "Lanyards"
- Update docs/brief.md to use "Lanyards" in the Overview
- Reformat an h3 element in page.tsx to span multiple lines for
  clearer structure and consistency with surrounding JSX