### PR TITLE
Fix #13: Read rkey from query params in PUT handler

### DIFF
--- a/src/app/api/profile/links/route.ts
+++ b/src/app/api/profile/links/route.ts
@@ -32,11 +32,14 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { rkey, ...updates } = await request.json();
+    const { searchParams } = new URL(request.url);
+    const rkey = searchParams.get('rkey');
 
     if (!rkey) {
       return NextResponse.json({ error: 'rkey is required' }, { status: 400 });
     }
+
+    const updates = await request.json();
 
     const repo = new ProfileRepository(agent);
     await repo.updateWebLink(rkey, updates);


### PR DESCRIPTION
## Summary
- Fixed the PUT handler in `/api/profile/links` to read `rkey` from query params instead of request body
- This matches how the form sends the data and is consistent with the DELETE handler

## Root Cause
The form was sending `rkey` as a query parameter, but the API was looking for it in the request body.

## Testing
- [x] Tested locally
- [x] No lint errors in changed file

Closes #13