### PR TITLE
Enhancement #9: Display CrossRef type in DOI metadata

### DIFF
--- a/src/components/research/ResearchForm.tsx
+++ b/src/components/research/ResearchForm.tsx
@@ -199,9 +199,14 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
                 <strong>Published:</strong> {new Date(resolvedMetadata.publicationDate).getFullYear()}
               </p>
             )}
+            {resolvedMetadata.type && (
+              <p className="text-sm text-blue-800 mb-1">
+                <strong>Type:</strong> {resolvedMetadata.type}
+              </p>
+            )}
             {resolvedMetadata.abstract && (
               <p className="text-sm text-blue-800 mb-1">
-                <strong>Abstract:</strong> {resolvedMetadata.abstract.substring(0, 200)}...
+                <strong>Abstract:</strong> {resolvedMetadata.abstract.substring(0, 200)}{resolvedMetadata.abstract.length > 200 ? '...' : ''}
               </p>
             )}
             {resolvedMetadata.url && (


### PR DESCRIPTION
## Summary
- Added CrossRef `type` field to the resolved metadata preview in the research form
- Fixed abstract truncation to be conditional on length

## Testing
- [x] Tested locally
- [x] Build succeeds
- [x] No lint errors

Closes #9