### PR TITLE
Enhancement #21: Use DOI type as source of truth

### DIFF
--- a/lexicons/link/work/work.json
+++ b/lexicons/link/work/work.json
@@ -16,19 +16,8 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "abstract",
-              "poster",
-              "paper",
-              "conference-proceeding",
-              "journal-article",
-              "book-chapter",
-              "book",
-              "preprint",
-              "dataset",
-              "other"
-            ],
-            "description": "Type of scholarly work"
+            "maxLength": 100,
+            "description": "Type of scholarly work (from CrossRef metadata)"
           },
           "title": {
             "type": "string",

--- a/src/app/api/profile/works/route.ts
+++ b/src/app/api/profile/works/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { doi, type, bypassDuplicateCheck } = await request.json();
+    const { doi, bypassDuplicateCheck } = await request.json();
 
     const repo = new ProfileRepository(agent);
 
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
 
     const work = {
       doi,
-      type,
+      type: metadata?.type || 'other',
       title: metadata?.title,
       authors: metadata?.authors,
       publicationDate: metadata?.publicationDate,
@@ -57,31 +57,13 @@ export async function POST(request: NextRequest) {
   }
 }
 
-export async function PUT(request: NextRequest) {
-  try {
-    const agent = await getAgent();
-
-    if (!agent) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { rkey, type } = await request.json();
-
-    if (!rkey) {
-      return NextResponse.json({ error: 'rkey is required' }, { status: 400 });
-    }
-
-    const repo = new ProfileRepository(agent);
-    await repo.updateWork(rkey, { type });
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error('Error updating work:', error);
-    return NextResponse.json(
-      { error: 'Failed to update work' },
-      { status: 500 }
-    );
-  }
+export async function PUT(_request: NextRequest) {
+  // Works are immutable - DOI and type come from CrossRef metadata
+  // This endpoint is kept for future extensibility
+  return NextResponse.json(
+    { error: 'Works cannot be updated. Delete and re-add instead.' },
+    { status: 400 }
+  );
 }
 
 export async function DELETE(request: NextRequest) {

--- a/src/app/dashboard/research/page.tsx
+++ b/src/app/dashboard/research/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth/session';
 import { getAgent } from '@/lib/auth/atproto';
 import { ProfileRepository } from '@/lib/data/repository';
+import { formatWorkType } from '@/lib/utils';
 import Link from 'next/link';
 
 export default async function ResearchPage() {
@@ -112,8 +113,8 @@ export default async function ResearchPage() {
                       </p>
                     )}
                     <div className="flex flex-wrap gap-2 items-center">
-                      <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded capitalize">
-                        {work.type.replace(/-/g, ' ')}
+                      <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">
+                        {formatWorkType(work.type)}
                       </span>
                       {work.venue && (
                         <span className="text-xs text-gray-600">

--- a/src/components/research/ResearchForm.tsx
+++ b/src/components/research/ResearchForm.tsx
@@ -1,42 +1,33 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import type { LinkWork, WorkType } from '@/types';
+import type { LinkWork } from '@/types';
+import { formatWorkType } from '@/lib/utils';
 
 interface ResearchFormProps {
   mode: 'create' | 'edit';
   initialData?: LinkWork & { rkey?: string };
 }
 
-const WORK_TYPES: { value: WorkType; label: string }[] = [
-  { value: 'abstract', label: 'Abstract' },
-  { value: 'poster', label: 'Poster' },
-  { value: 'paper', label: 'Paper' },
-  { value: 'conference-proceeding', label: 'Conference Proceeding' },
-  { value: 'journal-article', label: 'Journal Article' },
-  { value: 'book-chapter', label: 'Book Chapter' },
-  { value: 'book', label: 'Book' },
-  { value: 'preprint', label: 'Preprint' },
-  { value: 'dataset', label: 'Dataset' },
-  { value: 'other', label: 'Other' },
-];
-
 export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [resolvingDOI, setResolvingDOI] = useState(false);
   const [error, setError] = useState('');
-  const [resolvedMetadata, setResolvedMetadata] = useState<any>(null);
+  const [resolvedMetadata, setResolvedMetadata] = useState<{
+    title?: string;
+    authors?: string[];
+    journal?: string;
+    publicationDate?: string;
+    type?: string;
+    abstract?: string;
+    url?: string;
+  } | null>(null);
   const [showDuplicateWarning, setShowDuplicateWarning] = useState(false);
 
-  const [formData, setFormData] = useState<{
-    doi: string;
-    type: WorkType | '';
-    rkey?: string;
-  }>({
+  const [formData, setFormData] = useState({
     doi: initialData?.doi || '',
-    type: initialData?.type || '',
     rkey: initialData?.rkey,
   });
 
@@ -72,12 +63,10 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
     setShowDuplicateWarning(false);
 
     try {
-      const payload = mode === 'create'
-        ? { doi: formData.doi, type: formData.type, bypassDuplicateCheck }
-        : { rkey: formData.rkey, type: formData.type };
+      const payload = { doi: formData.doi, bypassDuplicateCheck };
 
       const response = await fetch('/api/profile/works', {
-        method: mode === 'create' ? 'POST' : 'PUT',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -201,7 +190,7 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
             )}
             {resolvedMetadata.type && (
               <p className="text-sm text-blue-800 mb-1">
-                <strong>Type:</strong> {resolvedMetadata.type}
+                <strong>Type:</strong> {formatWorkType(resolvedMetadata.type)}
               </p>
             )}
             {resolvedMetadata.abstract && (
@@ -250,6 +239,11 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
                 <strong>Published:</strong> {new Date(initialData.publicationDate).getFullYear()}
               </p>
             )}
+            {initialData.type && (
+              <p className="text-sm text-gray-800 mb-1">
+                <strong>Type:</strong> {formatWorkType(initialData.type)}
+              </p>
+            )}
             {('abstract' in initialData && initialData.abstract && typeof initialData.abstract === 'string') ? (
               <p className="text-sm text-gray-800 mb-1">
                 <strong>Abstract:</strong> {initialData.abstract.substring(0, 200)}{initialData.abstract.length > 200 ? '...' : ''}
@@ -270,27 +264,6 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
             ) : null}
           </div>
         )}
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Type *
-          </label>
-          <select
-            value={formData.type}
-            onChange={(e) =>
-              setFormData({ ...formData, type: e.target.value as WorkType })
-            }
-            required
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option value="">Select type...</option>
-            {WORK_TYPES.map((type) => (
-              <option key={type.value} value={type.value}>
-                {type.label}
-              </option>
-            ))}
-          </select>
-        </div>
       </div>
 
       {error && (
@@ -310,19 +283,15 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
       )}
 
       <div className="flex flex-col gap-3 mt-6">
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
-        >
-          {loading
-            ? mode === 'create'
-              ? 'Adding...'
-              : 'Saving...'
-            : mode === 'create'
-            ? 'Add Research'
-            : 'Save Changes'}
-        </button>
+        {mode === 'create' && (
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? 'Adding...' : 'Add Research'}
+          </button>
+        )}
 
         <button
           type="button"
@@ -330,7 +299,7 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
           disabled={loading}
           className="w-full py-3 px-6 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
         >
-          Cancel
+          {mode === 'edit' ? 'Back' : 'Cancel'}
         </button>
 
         {mode === 'edit' && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,3 +8,15 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Formats a work type string for human-readable display
+ * Converts hyphenated lowercase to Title Case
+ * Example: 'journal-article' → 'Journal Article'
+ */
+export function formatWorkType(type: string): string {
+  return type
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,7 +116,7 @@ export interface LinkEvent {
 
 export interface LinkWork {
   doi: string;
-  type: 'abstract' | 'poster' | 'paper' | 'conference-proceeding' | 'journal-article' | 'book-chapter' | 'book' | 'preprint' | 'dataset' | 'other';
+  type: string;
   title?: string;
   authors?: string[];
   publicationDate?: string;


### PR DESCRIPTION
## Summary
- Removed duplicate type selection - DOI metadata is now the source of truth
- Updated lexicon to accept any string for type field (from CrossRef)
- Removed type select input from research form
- Works are now immutable (delete and re-add to change)
- Added `formatWorkType()` utility for human-readable display
  - Example: `journal-article` → `Journal Article`

## Changes
- `lexicons/link/work/work.json` - type field now accepts any string
- `src/types/index.ts` - LinkWork.type is now string
- `src/app/api/profile/works/route.ts` - uses DOI type, PUT disabled
- `src/components/research/ResearchForm.tsx` - removed type select
- `src/app/dashboard/research/page.tsx` - uses formatWorkType
- `src/lib/utils.ts` - added formatWorkType utility

## Testing
- [x] Tested locally
- [x] Build succeeds
- [x] No lint errors

Closes #21