### PR TITLE
Fix #23: Support DOI input in all common formats

### DIFF
--- a/src/components/research/ResearchForm.tsx
+++ b/src/components/research/ResearchForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { LinkWork } from '@/types';
 import { formatWorkType } from '@/lib/utils';
+import { normalizeDOI } from '@/lib/data/doi';
 
 interface ResearchFormProps {
   mode: 'create' | 'edit';
@@ -30,6 +31,15 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
     doi: initialData?.doi || '',
     rkey: initialData?.rkey,
   });
+
+  const handleDOIBlur = () => {
+    if (formData.doi) {
+      const normalized = normalizeDOI(formData.doi);
+      if (normalized !== formData.doi) {
+        setFormData({ ...formData, doi: normalized });
+      }
+    }
+  };
 
   const handleResolveDOI = async () => {
     if (!formData.doi) return;
@@ -140,9 +150,10 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
               onChange={(e) =>
                 setFormData({ ...formData, doi: e.target.value })
               }
+              onBlur={handleDOIBlur}
               required
               disabled={mode === 'edit'}
-              placeholder="10.1234/example"
+              placeholder="10.1234/example or https://doi.org/10.1234/example"
               className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
             />
             {mode === 'create' && (
@@ -158,7 +169,7 @@ export default function ResearchForm({ mode, initialData }: ResearchFormProps) {
           </div>
           <p className="mt-1 text-sm text-gray-500">
             {mode === 'create'
-              ? 'Metadata will be automatically fetched from the DOI'
+              ? 'Paste any DOI format - URLs will be automatically cleaned'
               : 'DOI cannot be changed after creation'}
           </p>
         </div>

--- a/src/lib/data/doi.ts
+++ b/src/lib/data/doi.ts
@@ -14,6 +14,41 @@ function stripJATSTags(text: string): string {
   return text.replace(/<[^>]*>/g, '').trim();
 }
 
+/**
+ * Normalize a DOI to its canonical form (e.g., "10.1234/example")
+ *
+ * Supported input formats:
+ * - Plain DOI: 10.1234/example
+ * - With doi: prefix: doi:10.1234/example
+ * - HTTPS doi.org: https://doi.org/10.1234/example
+ * - HTTP doi.org: http://doi.org/10.1234/example
+ * - With www: https://www.doi.org/10.1234/example
+ * - dx.doi.org: https://dx.doi.org/10.1234/example
+ * - Handle.net: https://hdl.handle.net/10.1234/example
+ * - dx.hdl.handle.net: https://dx.hdl.handle.net/10.1234/example
+ * - URL with doi: prefix: https://doi.org/doi:10.1234/example
+ *
+ * @param input - DOI in any supported format
+ * @returns Normalized DOI starting with "10." or the original input if not recognized
+ */
+export function normalizeDOI(input: string): string {
+  if (!input) return input;
+
+  let doi = input.trim();
+
+  // Remove URL prefixes (http/https, www, dx subdomain, various hosts)
+  // Handles: doi.org, dx.doi.org, www.doi.org, hdl.handle.net, dx.hdl.handle.net
+  doi = doi.replace(
+    /^https?:\/\/(?:www\.)?(?:(?:dx\.)?doi\.org|(?:dx\.)?hdl\.handle\.net)\//i,
+    ''
+  );
+
+  // Remove doi: prefix (may appear after URL stripping or standalone)
+  doi = doi.replace(/^doi:/i, '');
+
+  return doi.trim();
+}
+
 export interface DOIMetadata {
   title?: string;
   authors?: string[];
@@ -26,8 +61,8 @@ export interface DOIMetadata {
 
 export async function resolveDOI(doi: string): Promise<DOIMetadata | null> {
   try {
-    // Clean DOI
-    const cleanDOI = doi.replace(/^(https?:\/\/)?(dx\.)?doi\.org\//, '');
+    // Clean DOI using normalizeDOI for comprehensive format support
+    const cleanDOI = normalizeDOI(doi);
 
     // Try CrossRef first
     const response = await fetch(


### PR DESCRIPTION
## Summary
- Add `normalizeDOI()` function with comprehensive format support
- Auto-clean DOI input on blur in the research form
- Update help text to indicate format flexibility

## Supported Formats
- Plain DOI: `10.1234/example`
- With prefix: `doi:10.1234/example`
- doi.org URLs: `https://doi.org/10.1234/example`
- dx.doi.org: `https://dx.doi.org/10.1234/example`
- hdl.handle.net: `https://hdl.handle.net/10.1234/example`
- www variants and HTTP/HTTPS

## Test plan
- [x] Paste a doi.org URL → should auto-clean to plain DOI
- [x] Paste a dx.doi.org URL → should auto-clean
- [x] Paste doi:10.xxx → should strip prefix
- [x] Plain DOI still works as before
- [x] Resolve button works with all formats

Closes #23