### PR TITLE
Fix #28: Prevent malformed DOI URLs

### DIFF
--- a/src/app/api/profile/works/route.ts
+++ b/src/app/api/profile/works/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAgent } from '@/lib/auth/atproto';
 import { ProfileRepository } from '@/lib/data/repository';
-import { resolveDOI } from '@/lib/data/doi';
+import { resolveDOI, normalizeDOI } from '@/lib/data/doi';
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,14 +11,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { doi, bypassDuplicateCheck } = await request.json();
+    const { doi: rawDoi, bypassDuplicateCheck } = await request.json();
+
+    // Normalize DOI to plain format (e.g., "10.1234/example")
+    // This ensures we never store URLs, only the canonical DOI identifier
+    const doi = normalizeDOI(rawDoi);
 
     const repo = new ProfileRepository(agent);
 
     // Check for duplicates unless explicitly bypassed
     if (!bypassDuplicateCheck) {
       const existingWorks = await repo.listWorks(agent.session?.did || '');
-      const duplicate = existingWorks.find((w) => w.doi === doi);
+      // Compare normalized DOIs to catch duplicates even if entered in different formats
+      const duplicate = existingWorks.find((w) => normalizeDOI(w.doi) === doi);
 
       if (duplicate) {
         return NextResponse.json(

--- a/src/app/dashboard/research/page.tsx
+++ b/src/app/dashboard/research/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from '@/lib/auth/session';
 import { getAgent } from '@/lib/auth/atproto';
 import { ProfileRepository } from '@/lib/data/repository';
 import { formatWorkType } from '@/lib/utils';
+import { normalizeDOI } from '@/lib/data/doi';
 import Link from 'next/link';
 
 export default async function ResearchPage() {
@@ -123,17 +124,18 @@ export default async function ResearchPage() {
                       )}
                       {work.publicationDate && (
                         <span className="text-xs text-gray-500">
-                          Published: {new Date(work.publicationDate).getFullYear()}
+                          Published:{' '}
+                          {new Date(work.publicationDate).getFullYear()}
                         </span>
                       )}
                     </div>
                     <a
-                      href={`https://doi.org/${work.doi}`}
+                      href={`https://doi.org/${normalizeDOI(work.doi)}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-xs text-blue-600 hover:underline mt-2 inline-block"
                     >
-                      DOI: {work.doi}
+                      {normalizeDOI(work.doi)}
                     </a>
                   </div>
                   <Link

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import QRCodeButton from './QRCodeButton';
+import { normalizeDOI } from '@/lib/data/doi';
 import type {
   Affiliation,
   Qualification,
@@ -302,12 +303,12 @@ export default function ProfileView({
                     <p className="text-sm text-gray-500">{work.venue}</p>
                   )}
                   <a
-                    href={`https://doi.org/${work.doi}`}
+                    href={`https://doi.org/${normalizeDOI(work.doi)}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-xs text-blue-600 hover:underline"
                   >
-                    {work.doi}
+                    {normalizeDOI(work.doi)}
                   </a>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- Normalizes DOIs to plain format before storage in API route
- Uses `normalizeDOI()` at all display points to construct proper URLs
- Prevents malformed URLs like `https://doi.org/https://doi.org/10.1234/...`
- Improves duplicate detection by comparing normalized DOIs

## Test plan
- [x] Add research with DOI in various formats (URL, doi:prefix, plain)
- [x] Verify stored DOI is plain format (e.g., "10.1234/example")
- [x] Verify links on research cards work correctly
- [x] Verify public profile DOI links work correctly
