### PR TITLE
Fix #47: Stack profile name and handle below avatar

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -106,7 +106,7 @@ export default function ProfileView({
 
           <CardContent className="pb-6">
             {/* Avatar and Basic Info */}
-            <div className="flex items-start gap-4 mb-4">
+            <div className="flex flex-col gap-3 mb-4">
               <div className={profile.banner ? '-mt-12' : 'pt-6'}>
                 <Avatar className="h-24 w-24 border-4 border-background">
                   <AvatarImage src={profile.avatar} alt={getDisplayName()} />
@@ -115,25 +115,23 @@ export default function ProfileView({
                   </AvatarFallback>
                 </Avatar>
               </div>
-              <div
-                className={`flex-1 min-w-0 ${profile.banner ? 'pt-4' : 'pt-6'}`}
-              >
-                <h1 className="text-2xl font-bold truncate">
+              <div className="space-y-1">
+                <h1 className="text-2xl font-bold leading-tight">
                   {getDisplayName()}
                 </h1>
                 <a
                   href={`https://bsky.app/profile/${profile.handle}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-primary hover:underline"
+                  className="block text-muted-foreground hover:text-primary hover:underline leading-normal"
                 >
                   @{profile.handle}
                 </a>
                 {profile.location &&
                   (profile.location.city || profile.location.country) && (
-                    <div className="flex items-center gap-1 text-sm text-foreground mb-4">
+                    <div className="flex items-center gap-1 text-sm text-foreground">
                       <MapPin className="h-4 w-4" />
-                      <span>
+                      <span className="leading-normal">
                         {profile.location.city && `${profile.location.city}, `}
                         {profile.location.country}
                       </span>
@@ -141,18 +139,6 @@ export default function ProfileView({
                   )}
               </div>
             </div>
-
-            {/* Location */}
-            {profile.location &&
-              (profile.location.city || profile.location.country) && (
-                <div className="flex items-center gap-1 text-sm text-foreground mb-4">
-                  <MapPin className="h-4 w-4" />
-                  <span>
-                    {profile.location.city && `${profile.location.city}, `}
-                    {profile.location.country}
-                  </span>
-                </div>
-              )}
 
             {/* Description */}
             {profile.description && (


### PR DESCRIPTION
## Summary
Changed profile header layout to match Bluesky's pattern where the display name and handle appear below the avatar instead of beside it, creating a cleaner and more responsive design.

## Changes
- Changed flex container from horizontal to vertical stacking
- Avatar now sits above name/handle/location instead of beside them
- Added proper `leading-*` classes for all text elements
- Removed duplicate location display code

## Testing
- [x] Tested locally on profile pages
- [x] Verified responsive layout
- [x] No lint errors introduced

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)