### PR TITLE
Fix #60: Qualifications page issues

### DIFF
--- a/lexicons/actor/biography/qualification.json
+++ b/lexicons/actor/biography/qualification.json
@@ -8,7 +8,7 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["title", "institution", "createdAt"],
+        "required": ["title", "type", "institution", "yearAwarded", "createdAt"],
         "properties": {
           "title": {
             "type": "string",
@@ -38,10 +38,11 @@
             "maxLength": 200,
             "description": "Field of study or specialization"
           },
-          "dateAwarded": {
-            "type": "string",
-            "format": "datetime",
-            "description": "Date the qualification was awarded"
+          "yearAwarded": {
+            "type": "integer",
+            "minimum": 1900,
+            "maximum": 2100,
+            "description": "Year the qualification was awarded (YYYY format)"
           },
           "location": {
             "type": "ref",

--- a/src/app/api/about/qualifications/route.ts
+++ b/src/app/api/about/qualifications/route.ts
@@ -16,11 +16,11 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { title, type, institution, field, dateAwarded, location } = body;
+    const { title, type, institution, field, yearAwarded, location } = body;
 
-    if (!title || !institution) {
+    if (!title || !type || !institution || !yearAwarded) {
       return NextResponse.json(
-        { error: 'Title and institution are required' },
+        { error: 'Title, type, institution, and year awarded are required' },
         { status: 400 }
       );
     }
@@ -28,10 +28,10 @@ export async function POST(request: NextRequest) {
     const repo = new ProfileRepository(agent);
     const rkey = await repo.createQualification({
       title,
-      type: type || 'other',
+      type,
       institution,
       field,
-      dateAwarded,
+      yearAwarded,
       location,
     });
 
@@ -68,11 +68,11 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { title, type, institution, field, dateAwarded, location } = body;
+    const { title, type, institution, field, yearAwarded, location } = body;
 
-    if (!title || !institution) {
+    if (!title || !type || !institution || !yearAwarded) {
       return NextResponse.json(
-        { error: 'Title and institution are required' },
+        { error: 'Title, type, institution, and year awarded are required' },
         { status: 400 }
       );
     }
@@ -80,10 +80,10 @@ export async function PUT(request: NextRequest) {
     const repo = new ProfileRepository(agent);
     await repo.updateQualification(rkey, {
       title,
-      type: type || 'other',
+      type,
       institution,
       field,
-      dateAwarded,
+      yearAwarded,
       location,
     });
 

--- a/src/app/dashboard/about/qualifications/page.tsx
+++ b/src/app/dashboard/about/qualifications/page.tsx
@@ -127,17 +127,12 @@ export default async function QualificationsPage() {
                   </div>
                 </CardHeader>
                 <CardContent className="pt-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    {qualification.field && (
-                      <span className="text-sm text-foreground">
-                        {qualification.field}
-                      </span>
+                  <div className="flex flex-wrap items-center gap-x-2 text-sm text-foreground">
+                    {qualification.field && <span>{qualification.field}</span>}
+                    {qualification.field && qualification.yearAwarded && (
+                      <span>•</span>
                     )}
-                    {qualification.dateAwarded && (
-                      <span className="text-sm text-foreground">
-                        {qualification.dateAwarded}
-                      </span>
-                    )}
+                    {qualification.yearAwarded && <span>{qualification.yearAwarded}</span>}
                   </div>
                 </CardContent>
               </Card>

--- a/src/components/about/QualificationForm.tsx
+++ b/src/components/about/QualificationForm.tsx
@@ -15,6 +15,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import CountrySelector from '@/components/CountrySelector/CountrySelector';
 import { AlertCircle } from 'lucide-react';
 
 interface QualificationFormProps {
@@ -41,16 +52,14 @@ export default function QualificationForm({
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [showDelete, setShowDelete] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   const [formData, setFormData] = useState({
     title: qualification?.title || '',
     type: (qualification?.type || 'bachelors') as QualificationType,
     institution: qualification?.institution || '',
     field: qualification?.field || '',
-    dateAwarded: qualification?.dateAwarded
-      ? new Date(qualification.dateAwarded).toISOString().split('T')[0]
-      : '',
+    yearAwarded: qualification?.yearAwarded?.toString() || '',
     city: qualification?.location?.city || '',
     country: qualification?.location?.country || '',
   });
@@ -66,9 +75,7 @@ export default function QualificationForm({
         type: formData.type,
         institution: formData.institution,
         field: formData.field || undefined,
-        dateAwarded: formData.dateAwarded
-          ? new Date(formData.dateAwarded).toISOString()
-          : undefined,
+        yearAwarded: parseInt(formData.yearAwarded, 10),
         location:
           formData.city || formData.country
             ? {
@@ -105,11 +112,6 @@ export default function QualificationForm({
   };
 
   const handleDelete = async () => {
-    if (!showDelete) {
-      setShowDelete(true);
-      return;
-    }
-
     setLoading(true);
     setError('');
 
@@ -130,166 +132,190 @@ export default function QualificationForm({
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
       setLoading(false);
-      setShowDelete(false);
+      setShowDeleteDialog(false);
     }
   };
 
   return (
-    <Card>
-      <CardContent className="pt-6">
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="title">Qualification Title *</Label>
-              <Input
-                id="title"
-                type="text"
-                value={formData.title}
-                onChange={(e) =>
-                  setFormData({ ...formData, title: e.target.value })
-                }
-                placeholder="e.g., PhD in Computer Science"
-                required
-                maxLength={200}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="type">Type</Label>
-              <Select
-                value={formData.type}
-                onValueChange={(value) =>
-                  setFormData({
-                    ...formData,
-                    type: value as QualificationType,
-                  })
-                }
-              >
-                <SelectTrigger id="type">
-                  <SelectValue placeholder="Select type" />
-                </SelectTrigger>
-                <SelectContent>
-                  {QUALIFICATION_TYPES.map((type) => (
-                    <SelectItem key={type.value} value={type.value}>
-                      {type.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="institution">Institution *</Label>
-              <Input
-                id="institution"
-                type="text"
-                value={formData.institution}
-                onChange={(e) =>
-                  setFormData({ ...formData, institution: e.target.value })
-                }
-                placeholder="e.g., Stanford University"
-                required
-                maxLength={300}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="field">Field of Study</Label>
-              <Input
-                id="field"
-                type="text"
-                value={formData.field}
-                onChange={(e) =>
-                  setFormData({ ...formData, field: e.target.value })
-                }
-                placeholder="e.g., Artificial Intelligence, Molecular Biology"
-                maxLength={200}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="dateAwarded">Date Awarded</Label>
-              <Input
-                id="dateAwarded"
-                type="date"
-                value={formData.dateAwarded}
-                onChange={(e) =>
-                  setFormData({ ...formData, dateAwarded: e.target.value })
-                }
-              />
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
+    <>
+      <Card>
+        <CardContent className="pt-6">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="city">City</Label>
+                <Label htmlFor="title">Qualification Title *</Label>
                 <Input
-                  id="city"
+                  id="title"
                   type="text"
-                  value={formData.city}
+                  value={formData.title}
                   onChange={(e) =>
-                    setFormData({ ...formData, city: e.target.value })
+                    setFormData({ ...formData, title: e.target.value })
                   }
-                  placeholder="e.g., Cambridge"
+                  placeholder="e.g., PhD in Computer Science"
+                  required
+                  maxLength={200}
                 />
               </div>
+
               <div className="space-y-2">
-                <Label htmlFor="country">Country</Label>
-                <Input
-                  id="country"
-                  type="text"
-                  value={formData.country}
-                  onChange={(e) =>
-                    setFormData({ ...formData, country: e.target.value })
+                <Label htmlFor="type">Type *</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(value) =>
+                    setFormData({
+                      ...formData,
+                      type: value as QualificationType,
+                    })
                   }
-                  placeholder="e.g., United States"
+                  required
+                >
+                  <SelectTrigger id="type">
+                    <SelectValue placeholder="Select type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {QUALIFICATION_TYPES.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="institution">Institution *</Label>
+                <Input
+                  id="institution"
+                  type="text"
+                  value={formData.institution}
+                  onChange={(e) =>
+                    setFormData({ ...formData, institution: e.target.value })
+                  }
+                  placeholder="e.g., Stanford University"
+                  required
+                  maxLength={300}
                 />
               </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="field">Field of Study</Label>
+                <Input
+                  id="field"
+                  type="text"
+                  value={formData.field}
+                  onChange={(e) =>
+                    setFormData({ ...formData, field: e.target.value })
+                  }
+                  placeholder="e.g., Artificial Intelligence, Molecular Biology"
+                  maxLength={200}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="yearAwarded">Date Awarded *</Label>
+                <Input
+                  id="yearAwarded"
+                  type="number"
+                  value={formData.yearAwarded}
+                  onChange={(e) =>
+                    setFormData({ ...formData, yearAwarded: e.target.value })
+                  }
+                  placeholder="e.g., 2020"
+                  required
+                  min="1900"
+                  max="2100"
+                  maxLength={4}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="city">City</Label>
+                  <Input
+                    id="city"
+                    type="text"
+                    value={formData.city}
+                    onChange={(e) =>
+                      setFormData({ ...formData, city: e.target.value })
+                    }
+                    placeholder="e.g., Cambridge"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="country">Country</Label>
+                  <CountrySelector
+                    id="country"
+                    value={formData.country}
+                    onChange={(value) =>
+                      setFormData({ ...formData, country: value })
+                    }
+                    placeholder="Select country..."
+                  />
+                </div>
+              </div>
             </div>
-          </div>
 
-          {error && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
 
-          <div className="flex flex-col gap-3">
-            <Button type="submit" disabled={loading} className="w-full">
-              {loading
-                ? 'Saving...'
-                : mode === 'create'
-                  ? 'Add Qualification'
-                  : 'Save Changes'}
-            </Button>
+            <div className="flex flex-col gap-3">
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading
+                  ? 'Saving...'
+                  : mode === 'create'
+                    ? 'Add Qualification'
+                    : 'Save Changes'}
+              </Button>
 
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => router.push('/dashboard/about/qualifications')}
-              className="w-full"
-            >
-              Cancel
-            </Button>
-
-            {mode === 'edit' && (
               <Button
                 type="button"
-                variant={showDelete ? 'destructive' : 'outline'}
-                onClick={handleDelete}
-                disabled={loading}
+                variant="outline"
+                onClick={() => router.push('/dashboard/about/qualifications')}
                 className="w-full"
               >
-                {loading
-                  ? 'Deleting...'
-                  : showDelete
-                    ? 'Click again to confirm deletion'
-                    : 'Delete Qualification'}
+                Cancel
               </Button>
-            )}
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+
+              {mode === 'edit' && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => setShowDeleteDialog(true)}
+                  disabled={loading}
+                  className="w-full"
+                >
+                  Delete Qualification
+                </Button>
+              )}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Qualification</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this qualification? This action
+              cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {loading ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -392,14 +392,13 @@ export default function ProfileView({
                   <p className="text-sm text-foreground leading-normal">
                     {qualification.institution}
                   </p>
-                  {qualification.field && (
-                    <p className="text-sm text-foreground leading-normal">
-                      {qualification.field}
-                    </p>
-                  )}
-                  {qualification.dateAwarded && (
-                    <p className="text-sm text-foreground leading-normal">
-                      {new Date(qualification.dateAwarded).getFullYear()}
+                  {(qualification.field || qualification.yearAwarded) && (
+                    <p className="text-sm text-foreground leading-normal flex items-center gap-x-2">
+                      {qualification.field && <span>{qualification.field}</span>}
+                      {qualification.field && qualification.yearAwarded && (
+                        <span>•</span>
+                      )}
+                      {qualification.yearAwarded && <span>{qualification.yearAwarded}</span>}
                     </p>
                   )}
                 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,10 +44,10 @@ export interface Affiliation {
 
 export interface Qualification {
   title: string;
-  type?: 'phd' | 'masters' | 'bachelors' | 'postdoc' | 'certification' | 'fellowship' | 'other';
+  type: 'phd' | 'masters' | 'bachelors' | 'postdoc' | 'certification' | 'fellowship' | 'other';
   institution: string;
   field?: string;
-  dateAwarded?: string;
+  yearAwarded: number;
   location?: {
     city?: string;
     country?: string;


### PR DESCRIPTION
## Summary

Fixes all issues identified in #60 for the qualifications management pages.

## Fixed Issues in /dashboard/about/qualifications

- ✅ Date format now displays year only (YYYY format)
- ✅ Field and year properly separated with bullet point

## Fixed Issues in /dashboard/about/qualifications/create and /dashboard/about/qualifications/edit

- ✅ Date awarded field changed to year only (YYYY), number input with max 4 digits
- ✅ Country field now uses CountrySelector component
- ✅ Type and Year Awarded are now required fields
- ✅ Delete button uses destructive style
- ✅ Delete action requires confirmation via AlertDialog

## Lexicon Changes

- Changed `dateAwarded` (datetime) to `yearAwarded` (integer)
- Added to required fields: `type` and `yearAwarded`
- Set constraints: min 1900, max 2100
- Types regenerated from updated lexicon

## Testing

- [x] Tested create form with required field validation
- [x] Tested edit form with required field validation  
- [x] Tested country selector
- [x] Tested delete confirmation dialog
- [x] Tested year input (4-digit max, range validation)
- [x] Verified dashboard display format
- [x] Verified public profile display format

## Closes

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)