### PR TITLE
Fix: Show Primary badge for primary affiliations

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -361,7 +361,12 @@ export default function ProfileView({
             <CardContent className="space-y-4">
               {currentAffiliations.map((affiliation, idx) => (
                 <div key={idx} className="space-y-1">
-                  <p className="font-black leading-normal">{affiliation.organizationName}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="font-black leading-normal">{affiliation.organizationName}</p>
+                    {affiliation.isPrimary && (
+                      <Badge variant="default">Primary</Badge>
+                    )}
+                  </div>
                   {affiliation.role && (
                     <p className="text-sm text-foreground leading-normal">
                       {affiliation.role}


### PR DESCRIPTION
## Summary

Fixes missing Primary badge on public profile pages when an affiliation is marked as primary.

### Problem

When users marked an affiliation as "Primary" in the dashboard, the badge was not visible on their public profile page, even though the data was being stored correctly.

### Solution

- Added conditional rendering of Primary badge in the ProfileView component
- Badge displays next to the organization name when `affiliation.isPrimary` is true
- Uses `variant="default"` for proper visibility and emphasis
- Wrapped organization name and badge in a flex container with gap for proper spacing

### Changes

**File: [src/components/profile/ProfileView.tsx](src/components/profile/ProfileView.tsx:364-369)**
- Lines 364-369: Added flex wrapper and conditional Primary badge rendering

### Testing

- [x] Verified badge appears when isPrimary is true
- [x] Confirmed layout and spacing look correct
- [x] Tested that non-primary affiliations don't show badge
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)