### PR TITLE
feat: add Bluesky stats to profile header

### DIFF
--- a/src/app/[handle]/page.tsx
+++ b/src/app/[handle]/page.tsx
@@ -117,6 +117,9 @@ export default async function ProfilePage({ params }: PageProps) {
                 country: location.country,
               }
             : undefined,
+          followersCount: bskyProfile.data.followersCount,
+          followsCount: bskyProfile.data.followsCount,
+          postsCount: bskyProfile.data.postsCount,
         }}
         affiliations={affiliations}
         qualifications={qualifications}

--- a/src/components/profile/BlueskyStats/BlueskyStats.constants.ts
+++ b/src/components/profile/BlueskyStats/BlueskyStats.constants.ts
@@ -1,0 +1,9 @@
+export const BLUESKY_BASE_URL = 'https://bsky.app/profile';
+
+export const formatCount = (count?: number): string => {
+  if (count === undefined) return '0';
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toString();
+};

--- a/src/components/profile/BlueskyStats/BlueskyStats.styles.ts
+++ b/src/components/profile/BlueskyStats/BlueskyStats.styles.ts
@@ -1,0 +1,6 @@
+export const styles = {
+  container: 'flex items-center gap-4 leading-normal',
+  stat: 'flex items-center gap-1',
+  statNumber: 'font-bold hover:underline',
+  statLabel: 'text-muted-foreground',
+} as const;

--- a/src/components/profile/BlueskyStats/BlueskyStats.tsx
+++ b/src/components/profile/BlueskyStats/BlueskyStats.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import type { BlueskyStatsProps } from './BlueskyStats.types';
+import { styles } from './BlueskyStats.styles';
+import { BLUESKY_BASE_URL, formatCount } from './BlueskyStats.constants';
+
+export default function BlueskyStats({
+  handle,
+  followersCount,
+  followsCount,
+  postsCount,
+}: BlueskyStatsProps) {
+  const stats = [
+    {
+      label: 'followers',
+      value: formatCount(followersCount),
+      href: `${BLUESKY_BASE_URL}/${handle}/followers`,
+    },
+    {
+      label: 'following',
+      value: formatCount(followsCount),
+      href: `${BLUESKY_BASE_URL}/${handle}/follows`,
+    },
+    {
+      label: 'posts',
+      value: formatCount(postsCount),
+      href: `${BLUESKY_BASE_URL}/${handle}`,
+    },
+  ];
+
+  return (
+    <div className={cn(styles.container)}>
+      {stats.map((stat) => (
+        <div key={stat.label} className={cn(styles.stat)}>
+          <Link
+            href={stat.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(styles.statNumber)}
+          >
+            {stat.value}
+          </Link>
+          <span className={cn(styles.statLabel)}>{stat.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/profile/BlueskyStats/BlueskyStats.types.ts
+++ b/src/components/profile/BlueskyStats/BlueskyStats.types.ts
@@ -1,0 +1,6 @@
+export interface BlueskyStatsProps {
+  handle: string;
+  followersCount?: number;
+  followsCount?: number;
+  postsCount?: number;
+}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import QRCodeButton from './QRCodeButton';
+import BlueskyStats from './BlueskyStats/BlueskyStats';
 import { normalizeDOI } from '@/lib/data/doi';
 import { formatDateUS, formatDisplayURL, formatWorkType } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -42,6 +43,9 @@ interface ProfileViewProps {
       city?: string;
       country?: string;
     };
+    followersCount?: number;
+    followsCount?: number;
+    postsCount?: number;
   };
   affiliations: (Affiliation & { rkey: string; uri: string })[];
   qualifications: (Qualification & { rkey: string; uri: string })[];
@@ -140,9 +144,15 @@ export default function ProfileView({
                 >
                   @{profile.handle}
                 </a>
+                <BlueskyStats
+                  handle={profile.handle}
+                  followersCount={profile.followersCount}
+                  followsCount={profile.followsCount}
+                  postsCount={profile.postsCount}
+                />
                 {profile.location &&
                   (profile.location.city || profile.location.country) && (
-                    <div className="flex items-center gap-1 text-sm text-foreground">
+                    <div className="flex items-center gap-1 text-foreground">
                       <MapPin className="h-4 w-4" />
                       <span className="leading-normal">
                         {profile.location.city && `${profile.location.city}, `}


### PR DESCRIPTION
## Summary
- Display Bluesky follower count, following count, and posts count on public profiles
- Stats appear under the handle in profile header, matching Bluesky's design
- Each stat number is a clickable link to the respective Bluesky page
- Large numbers are formatted with K suffix (e.g., 2.0K for 2000)

## Implementation
- Created BlueskyStats component with 4-file structure (types, styles, constants, component)
- Updated ProfileView to include stats in header
- Fetch stats from existing Bluesky API response (no additional API calls)
- Links open in new tab to Bluesky profile with appropriate tabs (followers, follows, posts)

## Testing
- [x] Tested locally with npm run dev
- [x] No lint errors
- [x] Component follows 4-file structure
- [x] Stats display correctly with proper formatting
- [x] Links navigate to correct Bluesky pages

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)